### PR TITLE
Adding a filter to class-wc-product-variation.php

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -396,7 +396,7 @@ class WC_Product_Variation extends WC_Product {
 	 * @return int
 	 */
 	public function get_stock_quantity() {
-		return true === $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity();
+		return apply_filters( 'woocommerce_get_stock_quantity', $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity(), $this );
 	}
 
 	/**


### PR DESCRIPTION
Within abstract-wc-product.php there is the filter 'woocommerce_get_stock_quantity' when calling the get_stock_quantity() function.
But there is no such filter for variable products when calling the class get_stock_quantity() function in class-wc-product-variation.php
Can the same filter be used for variations as well so we can check the object type ('simple' || 'variation') when calling this filter.